### PR TITLE
Avoid skipping path comparison by bounding beam search

### DIFF
--- a/gnn_rl_pipeline.py
+++ b/gnn_rl_pipeline.py
@@ -743,70 +743,84 @@ print(f"[RL] Legacy distance ≈ {env.total_distance:.2f} km, flow ≈ {flow_km:
 # A*, Dijkstra, Beam Search와의 거리 비교
 # ---------------------------------------------------------
 MAX_FAC_FOR_COMPARE = 200
+beam_width = 3
+max_expansion = 10000
 if num_fac > MAX_FAC_FOR_COMPARE:
-    print(f"\n[WARN] 시설 수가 {num_fac}개로 많아 경로 비교를 건너뜁니다 (>{MAX_FAC_FOR_COMPARE}).")
-else:
-    # 시설 그래프 생성
-    G = nx.Graph()
-    for i in range(num_fac):
-        G.add_node(i, lat=float(lat[i]), lon=float(lon[i]))
-    for (s, t), (dkm, _) in zip(edges_ff, attrs_ff):
-        if not G.has_edge(s, t) or G[s][t]['weight'] > dkm:
-            G.add_edge(s, t, weight=float(dkm))
+    print(f"\n[WARN] 시설 수가 {num_fac}개로 많지만 경로 비교를 수행합니다 (>{MAX_FAC_FOR_COMPARE}).")
+    beam_width = 2
+    max_expansion = 2000
 
-    # 휴리스틱 함수(A*)
-    def _heuristic(u: int, v: int) -> float:
-        n1, n2 = G.nodes[u], G.nodes[v]
-        return haversine(n1['lat'], n1['lon'], n2['lat'], n2['lon'])
+# 시설 그래프 생성
+G = nx.Graph()
+for i in range(num_fac):
+    G.add_node(i, lat=float(lat[i]), lon=float(lon[i]))
+for (s, t), (dkm, _) in zip(edges_ff, attrs_ff):
+    if not G.has_edge(s, t) or G[s][t]['weight'] > dkm:
+        G.add_edge(s, t, weight=float(dkm))
 
-    # Beam Search 간단 구현
-    def beam_search_path_length(G: nx.Graph, start: int, goal: int, beam_width: int = 3) -> float:
-        import heapq
-        frontier = [(0.0, [start])]
-        while frontier:
-            new_frontier = []
-            for cost, path in frontier:
-                node = path[-1]
-                if node == goal:
-                    return cost
-                for nb, data in G[node].items():
-                    heapq.heappush(new_frontier, (cost + data['weight'], path + [nb]))
-            frontier = heapq.nsmallest(beam_width, new_frontier)
+# 휴리스틱 함수(A*)
+def _heuristic(u: int, v: int) -> float:
+    n1, n2 = G.nodes[u], G.nodes[v]
+    return haversine(n1['lat'], n1['lon'], n2['lat'], n2['lon'])
+
+# Beam Search 간단 구현
+def beam_search_path_length(
+    G: nx.Graph, start: int, goal: int, beam_width: int = 3, max_expansion: int = 10000
+) -> float:
+    import heapq
+    frontier = [(0.0, [start])]
+    expansions = 0
+    while frontier and expansions < max_expansion:
+        new_frontier = []
+        for cost, path in frontier:
+            node = path[-1]
+            if node == goal:
+                return cost
+            for nb, data in G[node].items():
+                heapq.heappush(new_frontier, (cost + data['weight'], path + [nb]))
+                expansions += 1
+                if expansions >= max_expansion:
+                    break
+            if expansions >= max_expansion:
+                break
+        frontier = heapq.nsmallest(beam_width, new_frontier)
+    return float('inf')
+
+def _safe_path_length(func, *args, **kwargs) -> float:
+    """Wrapper returning infinity when no path exists."""
+    try:
+        return func(*args, **kwargs)
+    except nx.NetworkXNoPath:
         return float('inf')
 
-    def _safe_path_length(func, *args, **kwargs) -> float:
-        """Wrapper returning infinity when no path exists."""
-        try:
-            return func(*args, **kwargs)
-        except nx.NetworkXNoPath:
+# RL 플랜의 총 이동 거리 계산
+id_to_idx = {fac.iloc[i]["AssetID"]: i for i in range(num_fac)}
+def rl_total_distance(assign_list: List[Tuple[str, str]], assembly_idx: int) -> float:
+    seq = [id_to_idx[fid] for _, fid in assign_list]
+    seq.append(assembly_idx)
+    total = 0.0
+    for a, b in zip(seq[:-1], seq[1:]):
+        dist = _safe_path_length(nx.dijkstra_path_length, G, a, b, weight='weight')
+        if math.isinf(dist):
             return float('inf')
+        total += dist
+    return total
 
-    # RL 플랜의 총 이동 거리 계산
-    id_to_idx = {fac.iloc[i]["AssetID"]: i for i in range(num_fac)}
-    def rl_total_distance(assign_list: List[Tuple[str, str]], assembly_idx: int) -> float:
-        seq = [id_to_idx[fid] for _, fid in assign_list]
-        seq.append(assembly_idx)
-        total = 0.0
-        for a, b in zip(seq[:-1], seq[1:]):
-            dist = _safe_path_length(nx.dijkstra_path_length, G, a, b, weight='weight')
-            if math.isinf(dist):
-                return float('inf')
-            total += dist
-        return total
+start_idx = id_to_idx[assignments[0][1]]
+assembly_idx = int(asm_idx[0]) if len(asm_idx) > 0 else start_idx
 
-    start_idx = id_to_idx[assignments[0][1]]
-    assembly_idx = int(asm_idx[0]) if len(asm_idx) > 0 else start_idx
+dijkstra_len = _safe_path_length(nx.dijkstra_path_length, G, start_idx, assembly_idx, weight='weight')
+astar_len = _safe_path_length(nx.astar_path_length, G, start_idx, assembly_idx, heuristic=_heuristic, weight='weight')
+beam_len = beam_search_path_length(
+    G, start_idx, assembly_idx, beam_width=beam_width, max_expansion=max_expansion
+)
+rl_len = rl_total_distance(assignments, assembly_idx)
 
-    dijkstra_len = _safe_path_length(nx.dijkstra_path_length, G, start_idx, assembly_idx, weight='weight')
-    astar_len = _safe_path_length(nx.astar_path_length, G, start_idx, assembly_idx, heuristic=_heuristic, weight='weight')
-    beam_len = beam_search_path_length(G, start_idx, assembly_idx, beam_width=3)
-    rl_len = rl_total_distance(assignments, assembly_idx)
-
-    print("\n[COMPARE] 총 소요 거리 (km)")
-    print(f" - Dijkstra   : {dijkstra_len:.2f}")
-    print(f" - A*         : {astar_len:.2f}")
-    print(f" - Beam Search: {beam_len:.2f}")
-    print(f" - GNN+RL(top1): {rl_len:.2f}")
+print("\n[COMPARE] 총 소요 거리 (km)")
+print(f" - Dijkstra   : {dijkstra_len:.2f}")
+print(f" - A*         : {astar_len:.2f}")
+print(f" - Beam Search: {beam_len:.2f}")
+print(f" - GNN+RL(top1): {rl_len:.2f}")
 
 def visualize_sequence_route(plan: List[Tuple[str,str]], env, output_html: str, color: str = "blue"):
     """플랜 방문 순서를 직선 폴리라인으로 시각화"""


### PR DESCRIPTION
## Summary
- Always perform path comparisons even when facilities exceed the previous 200 limit
- Add beam search expansion cap and adaptive beam width to keep computation manageable

## Testing
- `python -m py_compile gnn_rl_pipeline.py`
- `python gnn_rl_pipeline.py` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_68a561b06d3083239ae63116717a6a40